### PR TITLE
ci: run vitest on PRs + fix stale factory tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,36 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  test:
+    name: Test server
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server/src/home-mind-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          submodules: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: server/src/home-mind-server/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck and build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
   build:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/server/src/home-mind-server/src/llm/factory.test.ts
+++ b/server/src/home-mind-server/src/llm/factory.test.ts
@@ -178,6 +178,8 @@ describe("createFactExtractor", () => {
       openaiApiKey: "oai-key",
       llmModel: "gpt-4o-mini",
       openaiBaseUrl: "https://proxy.example.com",
+      openaiResponseFormat: "json_object",
+      openaiMaxTokens: 512,
     } as Config;
 
     const extractor = createFactExtractor(config);
@@ -186,11 +188,13 @@ describe("createFactExtractor", () => {
     expect(OpenAIFactExtractorSpy).toHaveBeenCalledWith(
       "oai-key",
       "gpt-4o-mini",
-      "https://proxy.example.com"
+      "https://proxy.example.com",
+      "json_object",
+      512
     );
   });
 
-  it("passes undefined baseUrl when not set", () => {
+  it("passes undefined baseUrl/responseFormat/maxTokens when not set", () => {
     const config = {
       llmProvider: "openai",
       openaiApiKey: "oai-key",
@@ -202,6 +206,8 @@ describe("createFactExtractor", () => {
     expect(OpenAIFactExtractorSpy).toHaveBeenCalledWith(
       "oai-key",
       "gpt-4o-mini",
+      undefined,
+      undefined,
       undefined
     );
   });
@@ -218,7 +224,9 @@ describe("createFactExtractor", () => {
     expect(OpenAIFactExtractorSpy).toHaveBeenCalledWith(
       "ollama",
       "llama3.1",
-      "http://localhost:11434/v1"
+      "http://localhost:11434/v1",
+      undefined,
+      undefined
     );
   });
 
@@ -235,7 +243,9 @@ describe("createFactExtractor", () => {
     expect(OpenAIFactExtractorSpy).toHaveBeenCalledWith(
       "ollama",
       "llama3.1",
-      "http://192.168.1.50:11434/v1"
+      "http://192.168.1.50:11434/v1",
+      undefined,
+      undefined
     );
   });
 });


### PR DESCRIPTION
Closes the gap we hit clearing the Dependabot wave: the add-on CI only **compiled** the server (the Docker build runs `tsc`), so it never ran the test suite — a green check proved nothing about test/runtime behaviour. This was exactly the blind spot that made the express 5 bump risky to merge on a green checkmark.

## What this does
- **Adds a `test` job** — installs deps, runs `npm run build` (tsc) + `npm test` (vitest) under Node 22.
- **Gates the Docker `build` on it** (`needs: test`) so a failing test blocks the image/release.

## Also fixes the stale `factory.test.ts`
4 assertions were failing on `master` (unrelated to any dependency). `createFactExtractor` was extended to pass `openaiResponseFormat` + `openaiMaxTokens` as the 4th/5th args to `OpenAIFactExtractor`, but the tests still asserted the old 3-arg call, so `toHaveBeenCalledWith` failed on arity. Updated the assertions and extended the openai-provider test to actually cover both new params.

Suite is now **182 passed / 0 failed / 2 skipped** (the 2 skips are the Shodh integration tests that only run when `SHODH_TEST_URL` is set).

This PR will be the first to actually exercise the new test job — verifying the gate works end-to-end.