### PR TITLE
Pin the Shodh base image instead of tracking :latest

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -190,7 +190,7 @@ Optional bearer token auth via `API_TOKEN` env var. When set, all endpoints exce
 
 **The HA integration is not installed via HACS.** It ships inside this repo at `nives/rootfs/opt/nives/` and the `install-integration` s6 oneshot copies it into `/config/custom_components/nives/` on startup, version-gated against `manifest.json`. Users never touch HACS. (The old `home-mind-hacs` repo belongs to the OSS sister project and is archived under `Legacy/` — don't reference it here.)
 
-**Standalone dev only:** the `docker-compose.yml` in this directory runs `shodh` (port 3030) and `server` (port 3100) as two services for working on the server outside HA. That path uses the `varunshodh/shodh-memory:latest` image via a thin wrapper (`docker/shodh/Dockerfile`) that fixes volume permissions, and `deploy.sh` auto-generates `SHODH_API_KEY`. It is not how the add-on runs.
+**Standalone dev only:** the `docker-compose.yml` in this directory runs `shodh` (port 3030) and `server` (port 3100) as two services for working on the server outside HA. That path uses the `varunshodh/shodh-memory` image, pinned by tag and digest, via a thin wrapper (`docker/shodh/Dockerfile`) that fixes volume permissions, and `deploy.sh` auto-generates `SHODH_API_KEY`. It is not how the add-on runs.
 
 ## Known Limitations
 

--- a/server/docker/shodh/Dockerfile
+++ b/server/docker/shodh/Dockerfile
@@ -1,6 +1,11 @@
 # Shodh Memory Server
 # Thin wrapper around the official image to handle volume permission migration
-FROM varunshodh/shodh-memory:latest
+# Pinned by tag AND digest. `:latest` lets whatever is pushed next become our base
+# image without anyone choosing it, and it is not even reliably the newest — the
+# tag can lag. The digest is the half that actually binds: a tag can be re-pushed,
+# a digest cannot. 0.2.0 is the same version the add-on builds Shodh from, so dev
+# and production stay on one release.
+FROM varunshodh/shodh-memory:0.2.0@sha256:90047c1fd48181d49465dc4509a9d2006ef75616f7c7df276f25f3d399ddd51f
 
 USER root
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Aikido flagged `server/docker/shodh/Dockerfile` as critical, "automatic upgrades of base Docker images can lead to supply chain attacks".

## The exposure is narrower than critical

This file is the **standalone dev compose wrapper**, not the add-on. The shipped image never used it: `nives/Dockerfile` builds Shodh from release binaries at a pinned `SHODH_VERSION=v0.2.0`. No user has ever run an unpinned base image.

So this is a real fix to our development environment, not a shipped vulnerability. Worth doing anyway — `:latest` means whatever gets pushed next becomes our base image without anyone choosing it, and the tag is not reliably the newest either.

## The fix

Pinned by **tag and digest**:

```
FROM varunshodh/shodh-memory:0.2.0@sha256:90047c1fd4…
```

The digest is the half that actually binds — a tag can be re-pushed, a digest cannot. Today `0.2.0` and `latest` resolve to the *same* digest, so this changes nothing functionally, and `0.2.0` is the version the add-on already builds Shodh from, so dev and production sit on one release.

Docs updated to stop describing the wrapper as tracking `:latest`.

Same change goes to home-mind, which has the identical dev wrapper.